### PR TITLE
systemd: delete empty metadata before start

### DIFF
--- a/root/etc/systemd/system/netdata.service.d/cleanup.conf
+++ b/root/etc/systemd/system/netdata.service.d/cleanup.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=-/usr/bin/find /var/cache/netdata/ -type f -empty -delete


### PR DESCRIPTION
Avoid error on startup when metadata are corrupted.

Example of error inside /var/log/netdata.log:
```
  netdata INFO  : MAIN : Loading metadata log "/var/cache/netdata/dbengine/metadatalog-00000-00023.mlf".
  netdata ERROR : MAIN : File length is too short.
```
Example of the same error inside /var/log/messages:
```
  kernel: DBENGINE[3349]: segfault at 7fe3258b5020 ip 0000559e2cbd8674 sp 00007fe3218e4720 error 4 in netdata[559e2cb70000+13d000]
```

NethServer/dev#6333