### PR TITLE
systemd: expand template before start

### DIFF
--- a/root/etc/systemd/system/netdata.service.d/cleanup.conf
+++ b/root/etc/systemd/system/netdata.service.d/cleanup.conf
@@ -1,2 +1,5 @@
 [Service]
 ExecStartPre=-/usr/bin/find /var/cache/netdata/ -type f -empty -delete
+ReadWriteDirectories=/etc/netdata/
+ExecStartPre=-/sbin/e-smith/expand-template /etc/netdata/netdata.conf
+ExecStartPre=-/sbin/e-smith/expand-template /etc/netdata/conf.d/python.d.conf


### PR DESCRIPTION
Current installations will be fixed by template expansion fired inside the update event.
This patch will be effective from next upstream netdata update.

NethServer/dev#6528